### PR TITLE
Fix issue #368: startup mode validation

### DIFF
--- a/src/config/config_recovery.c
+++ b/src/config/config_recovery.c
@@ -128,6 +128,7 @@ BOOL ValidateTimerConfig(ConfigSnapshot* snapshot) {
     /* Validate startup mode */
     if (strlen(snapshot->startupMode) > 0) {
         if (strcmp(snapshot->startupMode, "COUNTDOWN") != 0 &&
+            strcmp(snapshot->startupMode, "DEFAULT") != 0 &&
             strcmp(snapshot->startupMode, "COUNT_UP") != 0 &&
             strcmp(snapshot->startupMode, "SHOW_TIME") != 0 &&
             strcmp(snapshot->startupMode, "NO_DISPLAY") != 0 &&

--- a/src/dialog/dialog_input.c
+++ b/src/dialog/dialog_input.c
@@ -368,7 +368,7 @@ INT_PTR CALLBACK DlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lParam) {
                             extern void WriteConfigDefaultStartTime(int seconds);
                             extern void WriteConfigStartupMode(const char* mode);
                             WriteConfigDefaultStartTime(total_seconds);
-                            WriteConfigStartupMode("COUNTDOWN");
+                            WriteConfigStartupMode("DEFAULT");
                             DestroyWindow(hwndDlg);
                         } else {
                             if (g_hwndParent) {

--- a/src/tray/tray_events.c
+++ b/src/tray/tray_events.c
@@ -180,7 +180,7 @@ void TogglePauseResumeTimer(HWND hwnd) {
 /**
  * @brief Persist startup mode and refresh UI
  * @param hwnd Window handle for redraw
- * @param mode Startup mode ("COUNTDOWN", "COUNTUP", "SHOW_TIME", "NO_DISPLAY")
+ * @param mode Startup mode ("DEFAULT", "COUNT_UP", "SHOW_TIME", "NO_DISPLAY")
  */
 void SetStartupMode(HWND hwnd, const char* mode) {
     WriteConfigStartupMode(mode);

--- a/src/tray/tray_menu_submenus.c
+++ b/src/tray/tray_menu_submenus.c
@@ -171,8 +171,8 @@ void BuildPresetManagementSubmenu(HMENU hMenu) {
     HMENU hStartupSettingsMenu = CreatePopupMenu();
     
     /* Use in-memory variable instead of reading config file each time */
-    AppendMenuW(hStartupSettingsMenu, MF_STRING | 
-                (strcmp(CLOCK_STARTUP_MODE, "COUNTDOWN") == 0 ? MF_CHECKED : 0),
+    AppendMenuW(hStartupSettingsMenu, MF_STRING |
+                (strcmp(CLOCK_STARTUP_MODE, "DEFAULT") == 0 ? MF_CHECKED : 0),
                 CLOCK_IDC_SET_COUNTDOWN_TIME,
                 GetLocalizedString(NULL, L"Countdown"));
     


### PR DESCRIPTION
## Summary

Fixed issue #368 by updating startup mode validation to properly support DEFAULT mode.

### Changes:

1. **src/config/config_recovery.c**: Added DEFAULT to valid startup modes in ValidateTimerConfig()
2. **src/dialog/dialog_input.c**: Changed default startup mode from COUNTDOWN to DEFAULT
3. **src/tray/tray_events.c**: Updated function documentation to reflect DEFAULT mode support
4. **src/tray/tray_menu_submenus.c**: Fixed menu item checking logic for DEFAULT mode

### Issue Description:
The issue stemmed from an inconsistency between COUNTDOWN and DEFAULT validation logic.

### Result:
Now the Countdown mode can be correctly saved and it will keep the status when catime starts.