### PR TITLE
refactor: decouple win32 from timer.c

### DIFF
--- a/include/timer/timer.h
+++ b/include/timer/timer.h
@@ -10,8 +10,10 @@
 #ifndef TIMER_H
 #define TIMER_H
 
+#include <stdbool.h>
 #include <windows.h>
 #include <time.h>
+#include <stdint.h>
 
 /* ============================================================================
  * Constants
@@ -46,16 +48,16 @@ typedef enum {
 #include <stdint.h>
 
 /* Global Timer State */
-extern BOOL CLOCK_IS_PAUSED;
-extern BOOL CLOCK_SHOW_CURRENT_TIME;
-extern BOOL CLOCK_USE_24HOUR;
-extern BOOL CLOCK_SHOW_SECONDS;
-extern BOOL CLOCK_COUNT_UP;
+extern bool CLOCK_IS_PAUSED;
+extern bool CLOCK_SHOW_CURRENT_TIME;
+extern bool CLOCK_USE_24HOUR;
+extern bool CLOCK_SHOW_SECONDS;
+extern bool CLOCK_COUNT_UP;
 extern char CLOCK_STARTUP_MODE[20];
 
-extern int CLOCK_TOTAL_TIME;
-extern int countdown_elapsed_time;
-extern int countup_elapsed_time;
+extern int32_t CLOCK_TOTAL_TIME;
+extern int32_t countdown_elapsed_time;
+extern int32_t countup_elapsed_time;
 
 /* Absolute Time State for Drift-Free Timing (Milliseconds) */
 extern int64_t g_target_end_time;  /* For Countdown: When the timer should end */
@@ -66,13 +68,13 @@ extern int64_t g_pause_start_time; /* Timestamp when pause began */
 int64_t GetAbsoluteTimeMs(void);
 
 extern time_t CLOCK_LAST_TIME_UPDATE;
-extern int last_displayed_second;
+extern int32_t last_displayed_second;
 
 /* Notification state (prevent duplicates) */
-extern BOOL countdown_message_shown;
-extern int pomodoro_work_cycles;
-extern int message_shown;
-extern int elapsed_time;
+extern bool countdown_message_shown;
+extern int32_t pomodoro_work_cycles;
+extern int32_t message_shown;
+extern int32_t elapsed_time;
 
 /* Input dialog */
 extern wchar_t inputText[256];
@@ -87,8 +89,8 @@ extern char CLOCK_TIMEOUT_WEBSITE_URL[MAX_PATH];
 /* Pomodoro settings - now in g_AppConfig.pomodoro */
 
 /* Quick presets */
-extern int time_options[MAX_TIME_OPTIONS];
-extern int time_options_count;
+extern int32_t time_options[MAX_TIME_OPTIONS];
+extern int32_t time_options_count;
 
 /* ============================================================================
  * Public API Functions
@@ -150,13 +152,12 @@ void TogglePauseTimer(void);
 
 /**
  * @brief Initialize high-precision counter
- * @return TRUE on success, FALSE if unsupported
  * 
  * @details
  * Establishes timing baseline via QueryPerformanceCounter.
  * Call when starting/resuming timer.
  */
-BOOL InitializeHighPrecisionTimer(void);
+void InitializeHighPrecisionTimer(void);
 
 /**
  * @brief Record timer baseline when system is about to suspend

--- a/include/window_procedure/window_utils.h
+++ b/include/window_procedure/window_utils.h
@@ -150,7 +150,7 @@ void UpdateConfigWithRefresh(HWND hwnd, const char* key, const char* value);
 /**
  * @brief Toggle boolean config value
  */
-void ToggleConfigBool(HWND hwnd, const char* key, BOOL* currentValue, BOOL needsRedraw);
+void ToggleConfigBool(HWND hwnd, const char* key, bool* currentValue, bool needsRedraw);
 
 /**
  * @brief Write config and redraw

--- a/src/main/main_initialization.c
+++ b/src/main/main_initialization.c
@@ -348,12 +348,6 @@ static void DropPrivileges(void) {
     }
 }
 
-extern int elapsed_time;
-extern int message_shown;
-extern int countdown_message_shown;
-extern int countdown_elapsed_time;
-extern int countup_elapsed_time;
-
 typedef enum {
     STARTUP_MODE_DEFAULT,
     STARTUP_MODE_COUNT_UP,
@@ -382,7 +376,7 @@ void HandleStartupMode(HWND hwnd) {
     
     switch (mode) {
         case STARTUP_MODE_COUNT_UP:
-            CLOCK_COUNT_UP = TRUE;
+            CLOCK_COUNT_UP = true;
             elapsed_time = 0;
             countup_elapsed_time = 0;
             
@@ -393,16 +387,16 @@ void HandleStartupMode(HWND hwnd) {
             ShowWindow(hwnd, SW_HIDE);
             MainTimer_Stop();
             elapsed_time = CLOCK_TOTAL_TIME;
-            CLOCK_IS_PAUSED = TRUE;
+            CLOCK_IS_PAUSED = true;
             
             message_shown = TRUE;
-            countdown_message_shown = TRUE;
+            countdown_message_shown = true;
             countdown_elapsed_time = 0;
             countup_elapsed_time = 0;
             break;
             
         case STARTUP_MODE_SHOW_TIME:
-            CLOCK_SHOW_CURRENT_TIME = TRUE;
+            CLOCK_SHOW_CURRENT_TIME = true;
             CLOCK_LAST_TIME_UPDATE = 0;
             break;
             
@@ -412,8 +406,8 @@ void HandleStartupMode(HWND hwnd) {
             
         case STARTUP_MODE_DEFAULT:
         default:
-            CLOCK_SHOW_CURRENT_TIME = FALSE;
-            CLOCK_COUNT_UP = FALSE;
+            CLOCK_SHOW_CURRENT_TIME = false;
+            CLOCK_COUNT_UP = false;
             countdown_elapsed_time = 0;
             
             if (CLOCK_TOTAL_TIME <= 0) {

--- a/src/menu_preview.c
+++ b/src/menu_preview.c
@@ -304,9 +304,9 @@ void ShowWindowForPreview(HWND hwnd) {
 
             g_previewState.createdPreviewTimer = TRUE;
 
-            CLOCK_SHOW_CURRENT_TIME = FALSE;
-            CLOCK_COUNT_UP = FALSE;
-            CLOCK_IS_PAUSED = TRUE;
+            CLOCK_SHOW_CURRENT_TIME = false;
+            CLOCK_COUNT_UP = false;
+            CLOCK_IS_PAUSED = true;
 
             CLOCK_TOTAL_TIME = previewTime;
             countdown_elapsed_time = 0;
@@ -341,8 +341,8 @@ void RestoreWindowVisibility(HWND hwnd) {
         WriteLog(LOG_LEVEL_INFO, "Clearing preview timer that we created");
         CLOCK_TOTAL_TIME = 0;
         countdown_elapsed_time = 0;
-        CLOCK_SHOW_CURRENT_TIME = FALSE;
-        CLOCK_COUNT_UP = FALSE;
+        CLOCK_SHOW_CURRENT_TIME = false;
+        CLOCK_COUNT_UP = false;
         
         /* Also clear g_target_end_time to avoid stale values */
         g_target_end_time = 0;

--- a/src/timer/timer.c
+++ b/src/timer/timer.c
@@ -14,10 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <windows.h>
 #include <time.h>
-#include <stdint.h>
 
 #define SECONDS_PER_MINUTE 60
 #define SECONDS_PER_HOUR 3600
@@ -25,36 +22,36 @@
 #define MILLISECONDS_PER_SECOND 1000.0
 #define DEFAULT_FALLBACK_TIME 60  /* 1 minute provides reasonable default when configuration is invalid */
 
-BOOL CLOCK_IS_PAUSED = FALSE;
-BOOL CLOCK_SHOW_CURRENT_TIME = FALSE;
-BOOL CLOCK_USE_24HOUR = TRUE;
-BOOL CLOCK_SHOW_SECONDS = TRUE;
-BOOL CLOCK_COUNT_UP = FALSE;
+bool CLOCK_IS_PAUSED = false;
+bool CLOCK_SHOW_CURRENT_TIME = false;
+bool CLOCK_USE_24HOUR = true;
+bool CLOCK_SHOW_SECONDS = true;
+bool CLOCK_COUNT_UP = false;
 char CLOCK_STARTUP_MODE[20] = "SHOW_TIME";
 
-int CLOCK_TOTAL_TIME = 0;
-int countdown_elapsed_time = 0;
-int countup_elapsed_time = 0;
+int32_t CLOCK_TOTAL_TIME = 0;
+int32_t countdown_elapsed_time = 0;
+int32_t countup_elapsed_time = 0;
 time_t CLOCK_LAST_TIME_UPDATE = 0;
-int last_displayed_second = -1;
+int32_t last_displayed_second = -1;
 
 static LARGE_INTEGER timer_frequency = {0};
 static LARGE_INTEGER timer_last_count = {0};
-static BOOL high_precision_timer_initialized = FALSE;
+static bool high_precision_timer_initialized = false;
 static int64_t s_suspend_mono_ms = 0;
 static int64_t s_suspend_tick_ms = 0;
-static BOOL s_suspend_snapshot_valid = FALSE;
+static bool s_suspend_snapshot_valid = false;
 
-BOOL countdown_message_shown = FALSE;
-int pomodoro_work_cycles = 0;
+bool countdown_message_shown = false;
+int32_t pomodoro_work_cycles = 0;
 
 TimeoutActionType CLOCK_TIMEOUT_ACTION = TIMEOUT_ACTION_MESSAGE;
 char CLOCK_TIMEOUT_TEXT[50] = "";
 char CLOCK_TIMEOUT_FILE_PATH[MAX_PATH] = "";
 char CLOCK_TIMEOUT_WEBSITE_URL[MAX_PATH] = "";
 
-int time_options[MAX_TIME_OPTIONS] = {0};
-int time_options_count = 0;
+int32_t time_options[MAX_TIME_OPTIONS] = {0};
+int32_t time_options_count = 0;
 
 /* Absolute Time State Definitions (Milliseconds) */
 int64_t g_target_end_time = 0;
@@ -81,7 +78,7 @@ int64_t GetAbsoluteTimeMs(void) {
 void Timer_OnSystemSuspend(void) {
     s_suspend_mono_ms = GetAbsoluteTimeMs();
     s_suspend_tick_ms = (int64_t)GetTickCount64();
-    s_suspend_snapshot_valid = TRUE;
+    s_suspend_snapshot_valid = true;
 }
 
 void Timer_OnSystemResume(void) {
@@ -92,7 +89,7 @@ void Timer_OnSystemResume(void) {
     int64_t mono_delta = now_mono_ms - s_suspend_mono_ms;
     int64_t tick_delta = now_tick_ms - s_suspend_tick_ms;
 
-    s_suspend_snapshot_valid = FALSE;
+    s_suspend_snapshot_valid = false;
 
     if (mono_delta < 0) mono_delta = 0;
     if (tick_delta < 0) tick_delta = 0;
@@ -113,15 +110,10 @@ void Timer_OnSystemResume(void) {
 }
 
 /** Reset QPC baseline to prevent time jumps after pause/resume */
-BOOL InitializeHighPrecisionTimer(void) {
-    if (!QueryPerformanceFrequency(&timer_frequency)) {
-        return FALSE;
-    }
-    if (!QueryPerformanceCounter(&timer_last_count)) {
-        return FALSE;
-    }
-    high_precision_timer_initialized = TRUE;
-    return TRUE;
+void InitializeHighPrecisionTimer(void) {
+    if (!QueryPerformanceFrequency(&timer_frequency)) return;
+    if (!QueryPerformanceCounter(&timer_last_count)) return;
+    high_precision_timer_initialized = true;
 }
 
 /** Leading spaces stabilize width when hours/minutes disappear during countdown */
@@ -307,8 +299,8 @@ void ResetTimer(void) {
         g_target_end_time = now + ((int64_t)CLOCK_TOTAL_TIME * 1000);
     }
     
-    CLOCK_IS_PAUSED = FALSE;
-    countdown_message_shown = FALSE;
+    CLOCK_IS_PAUSED = false;
+    countdown_message_shown = false;
     g_pause_start_time = 0;
     
     InitializeHighPrecisionTimer();
@@ -317,7 +309,7 @@ void ResetTimer(void) {
 
 /** Reinitialize timing baseline on resume to prevent time jumps */
 void TogglePauseTimer(void) {
-    BOOL was_paused = CLOCK_IS_PAUSED;
+    bool was_paused = CLOCK_IS_PAUSED;
     CLOCK_IS_PAUSED = !CLOCK_IS_PAUSED;
     
     int64_t now = GetAbsoluteTimeMs();

--- a/src/timer/timer_events.c
+++ b/src/timer/timer_events.c
@@ -239,8 +239,8 @@ static void HandleTimeoutActions(HWND hwnd) {
 
         case TIMEOUT_ACTION_SHOW_TIME:
             StopNotificationSound();
-            CLOCK_SHOW_CURRENT_TIME = TRUE;
-            CLOCK_COUNT_UP = FALSE;
+            CLOCK_SHOW_CURRENT_TIME = true;
+            CLOCK_COUNT_UP = false;
             /* Reset countdown state to prevent accidental completion trigger */
             CLOCK_TOTAL_TIME = 0;
             countdown_elapsed_time = 0;
@@ -252,14 +252,14 @@ static void HandleTimeoutActions(HWND hwnd) {
 
         case TIMEOUT_ACTION_COUNT_UP:
             StopNotificationSound();
-            CLOCK_COUNT_UP = TRUE;
-            CLOCK_SHOW_CURRENT_TIME = FALSE;
+            CLOCK_COUNT_UP = true;
+            CLOCK_SHOW_CURRENT_TIME = false;
             countup_elapsed_time = 0;
             elapsed_time = 0;
             g_start_time = GetAbsoluteTimeMs();
             message_shown = FALSE;
-            countdown_message_shown = FALSE;
-            CLOCK_IS_PAUSED = FALSE;
+            countdown_message_shown = false;
+            CLOCK_IS_PAUSED = false;
             ResetMillisecondAccumulator();
             MainTimer_Stop();
             MainTimer_Start(hwnd, GetTimerInterval());
@@ -355,8 +355,8 @@ static BOOL HandlePomodoroCompletion(HWND hwnd) {
         ShowNotification(hwnd, cycle_complete_text);
         PlayNotificationSound(hwnd);
 
-        CLOCK_COUNT_UP = FALSE;
-        CLOCK_SHOW_CURRENT_TIME = FALSE;
+        CLOCK_COUNT_UP = false;
+        CLOCK_SHOW_CURRENT_TIME = false;
         message_shown = TRUE;
         InvalidateRect(hwnd, NULL, TRUE);
         MainTimer_Stop();
@@ -392,10 +392,9 @@ static BOOL HandlePomodoroCompletion(HWND hwnd) {
     ResetTimerState(next_duration_sec);
     
     g_target_end_time += ((int64_t)next_duration_sec * 1000);
+
+    countdown_message_shown = false;
     
-    countdown_message_shown = FALSE;
-    
-    extern BOOL InitializeHighPrecisionTimer(void);
     InitializeHighPrecisionTimer();
     ResetMillisecondAccumulator();
     
@@ -513,7 +512,7 @@ static BOOL HandleMainTimer(HWND hwnd) {
     
     if (!CLOCK_COUNT_UP && CLOCK_TOTAL_TIME > 0 && countdown_elapsed_time >= CLOCK_TOTAL_TIME) {
         if (!countdown_message_shown) {
-            countdown_message_shown = TRUE;
+            countdown_message_shown = true;
             
             TrayAnimation_RecomputeTimerDelay();
             
@@ -564,7 +563,7 @@ void InitializePomodoro(void) {
     }
     
     countdown_elapsed_time = 0;
-    countdown_message_shown = FALSE;
+    countdown_message_shown = false;
     ResetMillisecondAccumulator();
 }
 

--- a/src/tray/tray_menu.c
+++ b/src/tray/tray_menu.c
@@ -31,15 +31,10 @@
 #include "color/color_parser.h"
 
 /* External dependencies needed for menu display logic */
-extern BOOL CLOCK_SHOW_CURRENT_TIME;
-extern BOOL CLOCK_USE_24HOUR;
 extern char CLOCK_TEXT_COLOR[COLOR_HEX_BUFFER];
 extern BOOL CLOCK_EDIT_MODE;
-extern BOOL CLOCK_COUNT_UP;
 extern int CLOCK_TOTAL_TIME;
 extern int countdown_elapsed_time;
-extern BOOL CLOCK_IS_PAUSED;
-extern BOOL CLOCK_SHOW_SECONDS;
 
 /* Pomodoro globals */
 extern int time_options_count;

--- a/src/tray/tray_menu_pomodoro.c
+++ b/src/tray/tray_menu_pomodoro.c
@@ -17,8 +17,6 @@
 /* External variables */
 extern int current_pomodoro_time_index;
 extern POMODORO_PHASE current_pomodoro_phase;
-extern BOOL CLOCK_SHOW_CURRENT_TIME;
-extern BOOL CLOCK_COUNT_UP;
 extern int CLOCK_TOTAL_TIME;
 
 #define MAX_POMODORO_TIMES 10

--- a/src/tray/tray_menu_submenus.c
+++ b/src/tray/tray_menu_submenus.c
@@ -30,8 +30,6 @@
 #include "color/color_parser.h"
 
 /* External dependencies from main.c/config.c */
-extern BOOL CLOCK_SHOW_CURRENT_TIME;
-extern BOOL CLOCK_USE_24HOUR;
 extern char CLOCK_TEXT_COLOR[COLOR_HEX_BUFFER];
 extern char CLOCK_TIMEOUT_WEBSITE_URL[MAX_PATH];
 extern char CLOCK_TIMEOUT_FILE_PATH[MAX_PATH];

--- a/src/window_procedure/window_commands_plugin.c
+++ b/src/window_procedure/window_commands_plugin.c
@@ -25,10 +25,6 @@
 /* External function declarations */
 extern void GetActiveColor(char* outColor, size_t bufferSize);
 
-extern BOOL CLOCK_SHOW_CURRENT_TIME;
-extern BOOL CLOCK_COUNT_UP;
-extern BOOL CLOCK_IS_PAUSED;
-
 /* ============================================================================
  * Plugin Command Handlers
  * ============================================================================ */
@@ -43,12 +39,12 @@ static BOOL HandlePluginToggle(HWND hwnd, int pluginIndex) {
         PluginData_Clear();
         
         /* Prevent countdown completion notification from triggering */
-        countdown_message_shown = TRUE;
+        countdown_message_shown = true;
         
         /* Switch to idle state - don't reset timer to avoid 1-minute fallback */
-        CLOCK_SHOW_CURRENT_TIME = FALSE;
-        CLOCK_COUNT_UP = FALSE;
-        CLOCK_IS_PAUSED = TRUE;
+        CLOCK_SHOW_CURRENT_TIME = false;
+        CLOCK_COUNT_UP = false;
+        CLOCK_IS_PAUSED = true;
         CLOCK_TOTAL_TIME = 0;
         countdown_elapsed_time = 0;
         MainTimer_Stop();
@@ -71,12 +67,12 @@ static BOOL HandlePluginToggle(HWND hwnd, int pluginIndex) {
     StopNotificationSound();
     
     /* Prevent countdown completion notification from triggering */
-    countdown_message_shown = TRUE;
+    countdown_message_shown = true;
     
     /* Reset timer flags */
-    CLOCK_SHOW_CURRENT_TIME = FALSE;
-    CLOCK_COUNT_UP = FALSE;
-    CLOCK_IS_PAUSED = TRUE;
+    CLOCK_SHOW_CURRENT_TIME = false;
+    CLOCK_COUNT_UP = false;
+    CLOCK_IS_PAUSED = true;
     
     /* Stop internal timer */
     MainTimer_Stop();
@@ -150,16 +146,16 @@ static BOOL HandleShowPluginFile(HWND hwnd) {
         PluginData_Clear();
         
         /* Prevent countdown completion notification from triggering */
-        countdown_message_shown = TRUE;
+        countdown_message_shown = true;
         
         if (hadCatimeTag) {
             /* Had <catime> tag - restore time display, keep timer */
             InvalidateRect(hwnd, NULL, TRUE);
         } else {
             /* No <catime> tag - switch to idle, don't reset timer to avoid 1-minute fallback */
-            CLOCK_SHOW_CURRENT_TIME = FALSE;
-            CLOCK_COUNT_UP = FALSE;
-            CLOCK_IS_PAUSED = TRUE;
+            CLOCK_SHOW_CURRENT_TIME = false;
+            CLOCK_COUNT_UP = false;
+            CLOCK_IS_PAUSED = true;
             CLOCK_TOTAL_TIME = 0;
             countdown_elapsed_time = 0;
             MainTimer_Stop();
@@ -173,14 +169,14 @@ static BOOL HandleShowPluginFile(HWND hwnd) {
     PluginData_SetActive(TRUE);
     
     /* Prevent countdown completion notification from triggering */
-    countdown_message_shown = TRUE;
+    countdown_message_shown = true;
     
     /* Check for <catime> tag */
     if (!PluginData_HasCatimeTag()) {
         MainTimer_Stop();
-        CLOCK_SHOW_CURRENT_TIME = FALSE;
-        CLOCK_COUNT_UP = FALSE;
-        CLOCK_IS_PAUSED = FALSE;
+        CLOCK_SHOW_CURRENT_TIME = false;
+        CLOCK_COUNT_UP = false;
+        CLOCK_IS_PAUSED = false;
     }
     
     /* Check if animated gradient needs timer for smooth animation */
@@ -215,12 +211,12 @@ void HandlePluginExit(HWND hwnd) {
     PluginData_Clear();
     
     /* Prevent countdown completion notification from triggering */
-    countdown_message_shown = TRUE;
+    countdown_message_shown = true;
     
     /* Switch to idle state - don't reset timer to avoid 1-minute fallback */
-    CLOCK_SHOW_CURRENT_TIME = FALSE;
-    CLOCK_COUNT_UP = FALSE;
-    CLOCK_IS_PAUSED = TRUE;
+    CLOCK_SHOW_CURRENT_TIME = false;
+    CLOCK_COUNT_UP = false;
+    CLOCK_IS_PAUSED = true;
     CLOCK_TOTAL_TIME = 0;
     countdown_elapsed_time = 0;
     MainTimer_Stop();

--- a/src/window_procedure/window_commands_timer.c
+++ b/src/window_procedure/window_commands_timer.c
@@ -84,7 +84,7 @@ LRESULT CmdCountUpReset(HWND hwnd, WPARAM wp, LPARAM lp) {
 LRESULT CmdCountdownReset(HWND hwnd, WPARAM wp, LPARAM lp) {
     (void)wp; (void)lp;
     CleanupBeforeTimerAction();
-    if (CLOCK_COUNT_UP) CLOCK_COUNT_UP = FALSE;
+    if (CLOCK_COUNT_UP) CLOCK_COUNT_UP = false;
     ResetTimer();
     MainTimer_Stop();
     ResetTimerWithInterval(hwnd);

--- a/src/window_procedure/window_config_handlers.c
+++ b/src/window_procedure/window_config_handlers.c
@@ -50,7 +50,7 @@ static BOOL LoadAndCompareInt(const char* section, const char* key, int* target,
     return FALSE;
 }
 
-static BOOL LoadAndCompareBool(const char* section, const char* key, BOOL* target, BOOL def) {
+static BOOL LoadAndCompareBool(const char* section, const char* key, bool* target, bool def) {
     BOOL temp = ReadConfigBool(section, key, def);
     if (temp != *target) {
         *target = temp;
@@ -148,7 +148,7 @@ LRESULT HandleAppDisplayChanged(HWND hwnd) {
 }
 
 LRESULT HandleAppTimerChanged(HWND hwnd) {
-    BOOL changed = FALSE;
+    bool changed = false;
 
     /* Basic timer settings */
     changed |= LoadAndCompareBool(CFG_SECTION_TIMER, CFG_KEY_USE_24HOUR,
@@ -162,7 +162,7 @@ LRESULT HandleAppTimerChanged(HWND hwnd) {
     TimeFormatType newFormat = TimeFormatType_FromStr(formatBuf);
     if (newFormat != g_AppConfig.display.time_format.format) {
         g_AppConfig.display.time_format.format = newFormat;
-        changed = TRUE;
+        changed = true;
     }
 
     /* Milliseconds display */
@@ -171,7 +171,7 @@ LRESULT HandleAppTimerChanged(HWND hwnd) {
         g_AppConfig.display.time_format.show_milliseconds = newShowMs;
         MainTimer_Stop();
         ResetTimerWithInterval(hwnd);
-        changed = TRUE;
+        changed = true;
     }
 
     /* Timeout settings */

--- a/src/window_procedure/window_helpers.c
+++ b/src/window_procedure/window_helpers.c
@@ -28,8 +28,6 @@
 void InvalidateIniCache(void);
 
 extern wchar_t inputText[256];
-extern int elapsed_time;
-extern int message_shown;
 extern char FONT_FILE_NAME[MAX_PATH];
 extern char FONT_INTERNAL_NAME[MAX_PATH];
 
@@ -38,14 +36,14 @@ extern char FONT_INTERNAL_NAME[MAX_PATH];
  * ============================================================================ */
 
 BOOL SwitchTimerMode(HWND hwnd, TimerMode mode, const TimerModeParams* params) {
-    BOOL wasShowingTime = CLOCK_SHOW_CURRENT_TIME;
+    bool wasShowingTime = CLOCK_SHOW_CURRENT_TIME;
     
     TimerModeParams defaultParams = {0, TRUE, TRUE, TRUE};  /* showWindow = TRUE by default */
     if (!params) params = &defaultParams;
     
     CLOCK_SHOW_CURRENT_TIME = (mode == TIMER_MODE_SHOW_TIME);
     CLOCK_COUNT_UP = (mode == TIMER_MODE_COUNTUP);
-    CLOCK_IS_PAUSED = FALSE;
+    CLOCK_IS_PAUSED = false;
     
     if (mode == TIMER_MODE_COUNTDOWN || mode == TIMER_MODE_POMODORO) {
         CLOCK_TOTAL_TIME = params->totalSeconds;
@@ -256,11 +254,11 @@ void ResetTimerStateToDefaults(void) {
     countdown_elapsed_time = 0;
     countup_elapsed_time = 0;
     message_shown = FALSE;
-    countdown_message_shown = FALSE;
+    countdown_message_shown = false;
     
-    CLOCK_COUNT_UP = FALSE;
-    CLOCK_SHOW_CURRENT_TIME = FALSE;
-    CLOCK_IS_PAUSED = FALSE;
+    CLOCK_COUNT_UP = false;
+    CLOCK_SHOW_CURRENT_TIME = false;
+    CLOCK_IS_PAUSED = false;
     
     current_pomodoro_phase = POMODORO_PHASE_IDLE;
     current_pomodoro_time_index = 0;

--- a/src/window_procedure/window_message_handlers.c
+++ b/src/window_procedure/window_message_handlers.c
@@ -574,12 +574,12 @@ LRESULT HandleDialogPluginSecurity(HWND hwnd, WPARAM wp, LPARAM lp) {
     StopNotificationSound();
 
     /* Prevent countdown completion notification from triggering */
-    countdown_message_shown = TRUE;
+    countdown_message_shown = true;
 
     /* Reset timer flags */
-    CLOCK_SHOW_CURRENT_TIME = FALSE;
-    CLOCK_COUNT_UP = FALSE;
-    CLOCK_IS_PAUSED = TRUE;
+    CLOCK_SHOW_CURRENT_TIME = false;
+    CLOCK_COUNT_UP = false;
+    CLOCK_IS_PAUSED = true;
 
     /* Stop internal timer */
     MainTimer_Stop();

--- a/src/window_procedure/window_procedure.c
+++ b/src/window_procedure/window_procedure.c
@@ -263,15 +263,15 @@ void ToggleShowTimeMode(HWND hwnd) {
         ResetTimerWithInterval(hwnd);
     } else {
         /* Turn off: switch to idle state (no display, no timer) */
-        CLOCK_SHOW_CURRENT_TIME = FALSE;
-        CLOCK_COUNT_UP = FALSE;
-        CLOCK_IS_PAUSED = FALSE;
+        CLOCK_SHOW_CURRENT_TIME = false;
+        CLOCK_COUNT_UP = false;
+        CLOCK_IS_PAUSED = false;
         CLOCK_TOTAL_TIME = 0;
         countdown_elapsed_time = 0;
         countup_elapsed_time = 0;
 
         /* Mark as shown to prevent notification when entering idle state */
-        countdown_message_shown = TRUE;
+        countdown_message_shown = true;
 
         MainTimer_Stop();
         InvalidateRect(hwnd, NULL, TRUE);
@@ -302,7 +302,7 @@ void StartDefaultCountDown(HWND hwnd) {
 
     if (g_AppConfig.timer.default_start_time > 0) {
         /* Only reset countdown_message_shown when actually starting countdown */
-        countdown_message_shown = FALSE;
+        countdown_message_shown = false;
         TimerModeParams params = {g_AppConfig.timer.default_start_time, TRUE, TRUE, TRUE};  /* showWindow = TRUE */
         SwitchTimerMode(hwnd, TIMER_MODE_COUNTDOWN, &params);
 
@@ -322,9 +322,9 @@ void StartPomodoroTimer(HWND hwnd) {
 
     InitializePomodoro();
 
-    CLOCK_SHOW_CURRENT_TIME = FALSE;
-    CLOCK_COUNT_UP = FALSE;
-    CLOCK_IS_PAUSED = FALSE;
+    CLOCK_SHOW_CURRENT_TIME = false;
+    CLOCK_COUNT_UP = false;
+    CLOCK_IS_PAUSED = false;
 
     /* Reset timer to set g_target_end_time for countdown display */
     ResetTimer();
@@ -356,7 +356,7 @@ void RestartCurrentTimer(HWND hwnd) {
 
     if (!CLOCK_SHOW_CURRENT_TIME) {
         message_shown = FALSE;
-        countdown_message_shown = FALSE;
+        countdown_message_shown = false;
 
         if (CLOCK_COUNT_UP) {
             countdown_elapsed_time = 0;
@@ -365,7 +365,7 @@ void RestartCurrentTimer(HWND hwnd) {
             countdown_elapsed_time = 0;
             elapsed_time = 0;
         }
-        CLOCK_IS_PAUSED = FALSE;
+        CLOCK_IS_PAUSED = false;
 
         /* Call ResetTimer() to properly reset g_target_end_time for countdown mode */
         ResetTimer();
@@ -411,7 +411,7 @@ void CleanupBeforeTimerAction(void) {
 BOOL StartCountdownWithTime(HWND hwnd, int seconds) {
     if (seconds <= 0) return FALSE;
 
-    countdown_message_shown = FALSE;
+    countdown_message_shown = false;
 
     if (current_pomodoro_phase != POMODORO_PHASE_IDLE) {
         ResetPomodoroState();

--- a/src/window_procedure/window_utils.c
+++ b/src/window_procedure/window_utils.c
@@ -139,7 +139,7 @@ void UpdateConfigWithRefresh(HWND hwnd, const char* key, const char* value) {
     }
 }
 
-void ToggleConfigBool(HWND hwnd, const char* key, BOOL* currentValue, BOOL needsRedraw) {
+void ToggleConfigBool(HWND hwnd, const char* key, bool* currentValue, bool needsRedraw) {
     *currentValue = !(*currentValue);
     WriteConfigKeyValue(key, *currentValue ? "TRUE" : "FALSE");
     if (needsRedraw && hwnd) {


### PR DESCRIPTION
replace Windows BOOL/TRUE/FALSE in timer.c  with standard stdbool and migrate to fixed-width integer types for timer state.

Remove some duplicated extern of the global variable in the timer.c, which is already externed by the timer.h.

## Ciallo～(∠・ω<)⌒★

### 🎉 You are awesome!

Thank you for taking the time to make this project better! We truly value your contribution.💕

---

### 📝 What's changed?
*(Briefly describe what you did or what problem you fixed)*

> **Refactor boolean usage and fix formatting issues**
> 
> - Transitioned various boolean state variables (e.g., `CLOCK_IS_PAUSED`, `countdown_message_shown`, `CLOCK_COUNT_UP`, `CLOCK_SHOW_CURRENT_TIME`) from uppercase macros (`TRUE`/`FALSE`) to standard C99 boolean keywords (`true`/`false`).
> - Updated the `ToggleConfigBool` function signature to use the standard `bool` type instead of the `BOOL` macro.
> - Removed trailing whitespaces and corrected minor formatting issues across multiple files (`main_timer.c`, `timer.c`, `window_utils.c`) to adhere to the project's coding style guidelines.

---

### 🤝 Don't worry about perfection

**We value your ideas and participation more than perfect code!**

If there are any style, testing, or detail issues, **we will help fix and polish them**. Just submit it, and we'll handle the rest!

---

*Thanks again! Happy to build this with you! 🙌*
