### PR TITLE
refactor (log): Replace some LUT, and restrict function scope

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -38,7 +38,8 @@ typedef enum {
     LOG_LEVEL_INFO,
     LOG_LEVEL_WARNING,
     LOG_LEVEL_ERROR,
-    LOG_LEVEL_FATAL
+    LOG_LEVEL_FATAL,
+    LOG_LEVEL_MAX,
 } LogLevel;
 
 /**
@@ -50,22 +51,6 @@ typedef struct {
     DWORD minBuild;
     const char* name;
 } OSVersionInfo;
-
-/**
- * @brief CPU architecture mapping structure
- */
-typedef struct {
-    WORD archId;
-    const char* name;
-} CPUArchInfo;
-
-/**
- * @brief Signal information mapping structure
- */
-typedef struct {
-    int signal;
-    const char* description;
-} SignalInfo;
 
 /* ============================================================================
  * Public API - Core Log System
@@ -172,17 +157,6 @@ void LogAdminPrivileges(void);
  * @param bufferSize Size of the output buffer in bytes
  */
 void GetLastErrorDescription(DWORD errorCode, char* buffer, int bufferSize);
-
-/**
- * @brief Format bytes to human-readable size string
- * 
- * Converts byte counts to KB/MB/GB with appropriate precision.
- * 
- * @param bytes Number of bytes to format
- * @param buffer Output buffer for formatted string
- * @param bufferSize Size of output buffer
- */
-void FormatBytes(ULONGLONG bytes, char* buffer, size_t bufferSize);
 
 /* ============================================================================
  * Public API - Exception Handling

--- a/include/log/log_core.h
+++ b/include/log/log_core.h
@@ -7,14 +7,6 @@
 #define LOG_CORE_H
 
 #include <windows.h>
-#include "../log.h"
-
-/**
- * Get log file path (shared with other log modules)
- * @param logPath Output buffer
- * @param size Buffer size
- */
-void GetLogFilePath(wchar_t* logPath, size_t size);
 
 /**
  * Get log file handle (for crash handler)

--- a/include/log/log_system_info.h
+++ b/include/log/log_system_info.h
@@ -33,13 +33,6 @@ void LogUACStatus(void);
  */
 void LogAdminPrivileges(void);
 
-/**
- * Format byte size to human-readable string
- * @param bytes Size in bytes
- * @param buffer Output buffer
- * @param bufferSize Buffer size
- */
-void FormatBytes(ULONGLONG bytes, char* buffer, size_t bufferSize);
 
 #endif /* LOG_SYSTEM_INFO_H */
 

--- a/src/log/log_core.c
+++ b/src/log/log_core.c
@@ -3,6 +3,7 @@
  * @brief Core logging implementation with rotation
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -12,14 +13,15 @@
 #include "log/log_core.h"
 #include "log/log_system_info.h"
 #include "config.h"
+#include "../include/log.h"
 #include "../../resource/resource.h"
 
-static const char* const LOG_LEVEL_STRINGS[] = {
-    "DEBUG",
-    "INFO",
-    "WARNING",
-    "ERROR",
-    "FATAL"
+static const char* const LOG_LEVEL_STRINGS[LOG_LEVEL_MAX] = {
+    [LOG_LEVEL_DEBUG] = "DEBUG",
+    [LOG_LEVEL_INFO] ="INFO",
+    [LOG_LEVEL_WARNING] = "WARNING",
+    [LOG_LEVEL_ERROR] = "ERROR",
+    [LOG_LEVEL_FATAL] = "FATAL"
 };
 
 static wchar_t LOG_FILE_PATH[MAX_PATH] = {0};
@@ -46,7 +48,10 @@ static void EnsureLogCSInitialized(void) {
     }
 }
 
-void GetLogFilePath(wchar_t* logPath, size_t size) {
+/**
+ * @breif Get log file path
+ */
+static void GetLogFilePath(void) {
     char configPath[MAX_PATH] = {0};
     GetConfigPath(configPath, MAX_PATH);
     
@@ -56,10 +61,10 @@ void GetLogFilePath(wchar_t* logPath, size_t size) {
     const wchar_t* lastSeparator = wcsrchr(configPathW, L'\\');
     if (lastSeparator) {
         size_t dirLen = lastSeparator - configPathW + 1;
-        wcsncpy(logPath, configPathW, dirLen);
-        _snwprintf_s(logPath + dirLen, size - dirLen, _TRUNCATE, L"Catime_Logs.log");
+        wcsncpy(LOG_FILE_PATH, configPathW, dirLen);
+        _snwprintf_s(LOG_FILE_PATH + dirLen, MAX_PATH - dirLen, _TRUNCATE, L"Catime_Logs.log");
     } else {
-        _snwprintf_s(logPath, size, _TRUNCATE, L"Catime_Logs.log");
+        _snwprintf_s(LOG_FILE_PATH, MAX_PATH, _TRUNCATE, L"Catime_Logs.log");
     }
 }
 
@@ -87,7 +92,7 @@ static ULONGLONG GetLogFileSize(void) {
 /** Open log file with shared delete permission */
 static BOOL OpenLogFile(void) {
     if (hLogFile != INVALID_HANDLE_VALUE) {
-        return TRUE;
+        return true;
     }
 
     hLogFile = CreateFileW(
@@ -101,18 +106,18 @@ static BOOL OpenLogFile(void) {
     );
 
     if (hLogFile == INVALID_HANDLE_VALUE) {
-        return FALSE;
+        return false;
     }
 
     /* Write UTF-8 BOM */
     DWORD written;
     WriteFile(hLogFile, UTF8_BOM, 3, &written, NULL);
 
-    return TRUE;
+    return true;
 }
 
 /** Check if log file still exists and reopen if deleted */
-static BOOL EnsureLogFileOpen(void) {
+static bool EnsureLogFileOpen(void) {
     if (hLogFile == INVALID_HANDLE_VALUE) {
         return OpenLogFile();
     }
@@ -126,7 +131,7 @@ static BOOL EnsureLogFileOpen(void) {
         return OpenLogFile();
     }
 
-    return TRUE;
+    return true;
 }
 
 /** Rotation: .log → .log.1 → .log.2 → .log.3 (oldest deleted) */
@@ -150,26 +155,28 @@ static void RotateLogFiles(void) {
 static void CheckAndRotateLog(void) {
     ULONGLONG fileSize = GetLogFileSize();
 
-    if (fileSize >= LOG_MAX_FILE_SIZE) {
-        if (hLogFile != INVALID_HANDLE_VALUE) {
-            CloseHandle(hLogFile);
-            hLogFile = INVALID_HANDLE_VALUE;
-        }
+    if (fileSize < LOG_MAX_FILE_SIZE) {
+        return;
+    }
+    
+    if (hLogFile != INVALID_HANDLE_VALUE) {
+        CloseHandle(hLogFile);
+        hLogFile = INVALID_HANDLE_VALUE;
+    }
 
-        RotateLogFiles();
+    RotateLogFiles();
 
-        OpenLogFile();
-        if (hLogFile != INVALID_HANDLE_VALUE) {
-            WriteLog(LOG_LEVEL_INFO, "Log file rotated (size exceeded %d MB)",
-                     LOG_MAX_FILE_SIZE / (1024 * 1024));
-        }
+    OpenLogFile();
+    if (hLogFile != INVALID_HANDLE_VALUE) {
+        WriteLog(LOG_LEVEL_INFO, "Log file rotated (size exceeded %d MB)",
+                    LOG_MAX_FILE_SIZE / (1024 * 1024));
     }
 }
 
 BOOL InitializeLogSystem(void) {
     EnsureLogCSInitialized();
 
-    GetLogFilePath(LOG_FILE_PATH, MAX_PATH);
+    GetLogFilePath();
 
     wchar_t dirPath[MAX_PATH] = {0};
     wcsncpy(dirPath, LOG_FILE_PATH, MAX_PATH - 1);
@@ -287,6 +294,10 @@ void CleanupLogSystem(void) {
 }
 
 void SetMinimumLogLevel(LogLevel minLevel) {
+    if (minLevel < 0 || minLevel >= LOG_LEVEL_MAX) {
+        minLevel = LOG_LEVEL_DEBUG;
+        return;
+    }
     minLogLevel = minLevel;
 }
 

--- a/src/log/log_exception.c
+++ b/src/log/log_exception.c
@@ -12,28 +12,20 @@
 #include "log.h"
 #include "main/main_single_instance.h"
 
-static const SignalInfo SIGNAL_TABLE[] = {
-    {SIGFPE,   "Floating point exception"},
-    {SIGILL,   "Illegal instruction"},
-    {SIGSEGV,  "Segmentation fault/memory access error"},
-    {SIGTERM,  "Termination signal"},
-    {SIGABRT,  "Abnormal termination/abort"},
-    {SIGINT,   "User interrupt"},
-};
 
 /** Atomic flag prevents deadlock in crash handler */
 static volatile LONG inCrashHandler = 0;
 
 static const char* GetSignalDescription(int signal) {
-    const size_t tableSize = sizeof(SIGNAL_TABLE) / sizeof(SIGNAL_TABLE[0]);
-    
-    for (size_t i = 0; i < tableSize; i++) {
-        if (SIGNAL_TABLE[i].signal == signal) {
-            return SIGNAL_TABLE[i].description;
-        }
+    switch (signal) {
+        case SIGFPE:  return "Floating point exception";
+        case SIGILL:  return "Illegal instruction";
+        case SIGSEGV: return "Segmentation fault/memory access error";
+        case SIGTERM: return "Termination signal";
+        case SIGABRT: return "Abnormal termination/abort";
+        case SIGINT:  return "User interrupt";
+        default:      return "Unknown signal";
     }
-    
-    return "Unknown signal";
 }
 
 /**

--- a/src/log/log_system_info.c
+++ b/src/log/log_system_info.c
@@ -3,6 +3,7 @@
  * @brief System information collection implementation
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <windows.h>
 #include "log/log_system_info.h"
@@ -11,6 +12,17 @@
 #ifndef PROCESSOR_ARCHITECTURE_ARM64
 #define PROCESSOR_ARCHITECTURE_ARM64 12
 #endif
+
+#ifndef likely
+#define likely(x)   __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
+#define KB  (1024.0)
+#define MB  (KB * 1024.0)
+#define GB  (MB * 1024.0)
 
 /** Easy to extend for future Windows versions */
 static const OSVersionInfo OS_VERSION_TABLE[] = {
@@ -25,14 +37,13 @@ static const OSVersionInfo OS_VERSION_TABLE[] = {
     {5,  0, 0,     "Windows 2000"},
 };
 
-static const CPUArchInfo CPU_ARCH_TABLE[] = {
-    {PROCESSOR_ARCHITECTURE_AMD64, "x64 (AMD64)"},
-    {PROCESSOR_ARCHITECTURE_INTEL, "x86 (Intel)"},
-    {PROCESSOR_ARCHITECTURE_ARM,   "ARM"},
-    {PROCESSOR_ARCHITECTURE_ARM64, "ARM64"},
-};
-
-static const char* GetOSVersionName(DWORD major, DWORD minor, DWORD build) {
+static const char* GetOSVersionName(const OSVersionInfo* osVersion) {
+    if (unlikely(!osVersion)){
+        return "Invalid OS version information";
+    }
+    const DWORD major = osVersion->major;
+    const DWORD minor = osVersion->minor;
+    const DWORD build = osVersion->minBuild;
     const size_t tableSize = sizeof(OS_VERSION_TABLE) / sizeof(OS_VERSION_TABLE[0]);
     
     for (size_t i = 0; i < tableSize; i++) {
@@ -48,59 +59,47 @@ static const char* GetOSVersionName(DWORD major, DWORD minor, DWORD build) {
 }
 
 static const char* GetCPUArchitectureName(WORD archId) {
-    const size_t tableSize = sizeof(CPU_ARCH_TABLE) / sizeof(CPU_ARCH_TABLE[0]);
-    
-    for (size_t i = 0; i < tableSize; i++) {
-        if (CPU_ARCH_TABLE[i].archId == archId) {
-            return CPU_ARCH_TABLE[i].name;
-        }
+    switch (archId) {
+        case PROCESSOR_ARCHITECTURE_AMD64: return "x64 (AMD64)";
+        case PROCESSOR_ARCHITECTURE_INTEL: return "x86 (Intel)";
+        case PROCESSOR_ARCHITECTURE_ARM:   return "ARM";
+        case PROCESSOR_ARCHITECTURE_ARM64: return "ARM64";
+        default: return "Unknown architecture";
     }
-    
-    return "Unknown architecture";
 }
 
 /** RtlGetVersion bypasses app manifest compatibility layer */
-static BOOL GetOSVersionInfo(DWORD* major, DWORD* minor, DWORD* build) {
-    if (!major || !minor || !build) {
-        return FALSE;
+static bool GetOSVersionInfo(OSVersionInfo* osVersion) {
+    if (unlikely(!osVersion)) {
+        return false;
     }
-    
-    *major = 0;
-    *minor = 0;
-    *build = 0;
-    
+        
     typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
     HMODULE hNtdll = GetModuleHandleW(L"ntdll.dll");
     
-    if (!hNtdll) {
-        return FALSE;
-    }
+    if (unlikely(!hNtdll)) return false;
     
     RtlGetVersionPtr pRtlGetVersion = (RtlGetVersionPtr)GetProcAddress(hNtdll, "RtlGetVersion");
-    if (!pRtlGetVersion) {
-        return FALSE;
+    if (unlikely(!pRtlGetVersion)) return false;
+    
+    RTL_OSVERSIONINFOW rovi = {.dwOSVersionInfoSize = sizeof(rovi)};
+    
+    if (likely(pRtlGetVersion(&rovi) == 0)) {
+        osVersion->major = rovi.dwMajorVersion;
+        osVersion->minor = rovi.dwMinorVersion;
+        osVersion->minBuild = rovi.dwBuildNumber;
+        return true;
     }
     
-    RTL_OSVERSIONINFOW rovi = {0};
-    rovi.dwOSVersionInfoSize = sizeof(rovi);
-    
-    if (pRtlGetVersion(&rovi) == 0) {
-        *major = rovi.dwMajorVersion;
-        *minor = rovi.dwMinorVersion;
-        *build = rovi.dwBuildNumber;
-        return TRUE;
-    }
-    
-    return FALSE;
+    return false;
 }
 
 void LogOSVersion(void) {
-    DWORD major = 0, minor = 0, build = 0;
-    
-    if (GetOSVersionInfo(&major, &minor, &build)) {
-        const char* osName = GetOSVersionName(major, minor, build);
+    OSVersionInfo osVersion = {0};
+    if (likely(GetOSVersionInfo(&osVersion))) {
+        osVersion.name = GetOSVersionName(&osVersion);
         WriteLog(LOG_LEVEL_INFO, "Operating System: %s (%lu.%lu) Build %lu", 
-                 osName, major, minor, build);
+                 osVersion.name, osVersion.major, osVersion.minor, osVersion.minBuild);
     } else {
         WriteLog(LOG_LEVEL_WARNING, "Unable to retrieve OS version information");
     }
@@ -114,11 +113,32 @@ void LogCPUArchitecture(void) {
     WriteLog(LOG_LEVEL_INFO, "CPU Architecture: %s", archName);
 }
 
+/**
+ * Format byte size to human-readable string
+ * @param bytes Size in bytes
+ * @param buffer Output buffer
+ * @param bufferSize Buffer size
+ */
+static void FormatBytes(DWORDLONG bytes, char* buffer, size_t bufferSize) {
+    if (unlikely(!buffer || bufferSize == 0)) return;
+    
+    
+    if (bytes >= GB) {
+        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f GB", bytes / GB);
+    } else if (bytes >= MB) {
+        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f MB", bytes / MB);
+    } else if (bytes >= KB) {
+        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f KB", bytes / KB);
+    } else {
+        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%llu bytes", bytes);
+    }
+}
+
 void LogMemoryInfo(void) {
     MEMORYSTATUSEX memInfo;
     memInfo.dwLength = sizeof(MEMORYSTATUSEX);
     
-    if (GlobalMemoryStatusEx(&memInfo)) {
+    if (likely(GlobalMemoryStatusEx(&memInfo))) {
         char totalStr[64] = {0};
         char usedStr[64] = {0};
         
@@ -133,7 +153,7 @@ void LogMemoryInfo(void) {
 }
 
 void LogUACStatus(void) {
-    BOOL uacEnabled = FALSE;
+    bool uacEnabled = false;
     HANDLE hToken;
     
     if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
@@ -164,25 +184,5 @@ void LogAdminPrivileges(void) {
     }
     
     WriteLog(LOG_LEVEL_INFO, "Administrator Privileges: %s", isAdmin ? "Yes" : "No");
-}
-
-void FormatBytes(ULONGLONG bytes, char* buffer, size_t bufferSize) {
-    if (!buffer || bufferSize == 0) {
-        return;
-    }
-    
-    const double KB = 1024.0;
-    const double MB = KB * 1024.0;
-    const double GB = MB * 1024.0;
-    
-    if (bytes >= GB) {
-        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f GB", bytes / GB);
-    } else if (bytes >= MB) {
-        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f MB", bytes / MB);
-    } else if (bytes >= KB) {
-        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%.2f KB", bytes / KB);
-    } else {
-        _snprintf_s(buffer, bufferSize, _TRUNCATE, "%llu bytes", bytes);
-    }
 }
 


### PR DESCRIPTION
## Ciallo～(∠・ω<)⌒★

### 🎉 You are awesome!

Thank you for taking the time to make this project better! We truly value your contribution.💕

---

### 📝 What's changed?
*(Briefly describe what you did or what problem you fixed)*

> For the `log_exception.c`, the `GetSignalDescription` find the signal string related to the signal ID by loop over each element in the table.
> 
> We use the switch to directly jump to the specific signal to return the description of that signal.
> 
> This remove the LUT and avoid the branch-prediction in the for-loop.
> 
> Something similar refactorization is performed to the `GetCPUArchitectureName` in the `log_system_info.c`.
> 
> Since we are not using the LUT, we can remove the structure definition `CPUArchInfo` and `SignalInfo`  from the `log.h`.
> 
> In the `log_system_info.c`, the argument of `GetOSVersionInfo` is alomost the same as `OSVersionInfo` structure, so we directly pass the pointer of structure as the input, rather than input 3 pointer as arguments.
> 
> `GetOSVersionName` functions is also refactored for the same reason.
> 
> `FormatBytes` function is only used in `log_system_info.c`, so we add the restrict to it.
> 
> We do the same thing to the `GetLogFilePath` function.
> 
> To prevent from the change of the log level order, we use the designated initialization to assign the tag of each log level.
> 
> We also add the `LOG_LEVEL_MAX` to `LogLevel` so that we can check if the input of `SetMinimumLogLevel` is a valid number.


---

### 🤝 Don't worry about perfection

**We value your ideas and participation more than perfect code!**

If there are any style, testing, or detail issues, **we will help fix and polish them**. Just submit it, and we'll handle the rest!

---

*Thanks again! Happy to build this with you! 🙌*
