### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,11 +256,11 @@ build.bat                         # Windows
 
 ## 🌟Star History
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/de.md
+++ b/i18n/de.md
@@ -231,11 +231,11 @@ build.bat                         # Windows
 
 ## 🌟 Star-Verlauf
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/en.md
+++ b/i18n/en.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Star History
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/es.md
+++ b/i18n/es.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Historial de Star
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/fr.md
+++ b/i18n/fr.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Historique des Stars
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/ja.md
+++ b/i18n/ja.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Star履歴
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/ko.md
+++ b/i18n/ko.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Star 히스토리
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/pt.md
+++ b/i18n/pt.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 Historico de Stars
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/ru.md
+++ b/i18n/ru.md
@@ -229,11 +229,11 @@ build.bat                         # Windows
 
 ## 🌟 История Star
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/zh-Hant.md
+++ b/i18n/zh-Hant.md
@@ -232,11 +232,11 @@ build.bat                         # Windows
 
 ## 🌟 Star 歷史
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 

--- a/i18n/zh_CN.md
+++ b/i18n/zh_CN.md
@@ -232,11 +232,11 @@ build.bat                         # Windows
 
 ## 🌟 Star 历史
 
-<a href="https://www.star-history.com/#vladelaina/Catime&Date">
+<a href="https://star-history.dera.page/#vladelaina/Catime&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=vladelaina/Catime&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=vladelaina/Catime&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is broken and no longer renders, so the project's growth history is invisible. This change points the chart to a working alternative across the main README and every localized version so it displays correctly again.